### PR TITLE
Skip unused locals check at type level

### DIFF
--- a/maasglobal-template-ts/tsconfig.json
+++ b/maasglobal-template-ts/tsconfig.json
@@ -19,7 +19,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "types"],
-    "noUnusedLocals": true,
     "downlevelIteration": true,
     "declaration": true,
     "outDir": "./lib"


### PR DESCRIPTION
Unused locals are not type errors. Makes more sense to check the with a linter.